### PR TITLE
Added script parameter block

### DIFF
--- a/MerideumParser.g4
+++ b/MerideumParser.g4
@@ -6,16 +6,16 @@ options {
 
 parse: scriptDefinition EOF;
 
-scriptDefinition: scriptType WS* simpleIdentifier WS* scriptParameterBlock? CURLY_L WS* block WS* CURLY_R;
+scriptDefinition: scriptType WS* simpleIdentifier WS* scriptParameters? CURLY_L WS* block WS* CURLY_R;
 
 scriptType: REQUEST | CONTRACT;
 
-scriptParameterBlock
-    : PAREN_L WS* scriptParameters? WS* PAREN_R
+scriptParameters
+    : PAREN_L WS* scriptParameter WS* (COMMA WS* scriptParameter)*? WS* PAREN_R
     ;
 
-scriptParameters
-    : simpleIdentifier WS* typeDeclaration WS* (COMMA WS* simpleIdentifier WS* typeDeclaration)*?
+scriptParameter
+    : simpleIdentifier WS* typeDeclaration
     ;
 
 block: (importResource)* WS* (statement WS*)*;


### PR DESCRIPTION
Added the script parameter block to the script definition.

Example:
```
contract myContract(foo: string, count: int) {
    ...
}
```